### PR TITLE
updated (C) info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-#  Copyright (C) 2018-2019 LEIDOS.
+#  Copyright (C) 2018-2020 LEIDOS.
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of

--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -17,7 +17,7 @@
 USERNAME=usdotfhwastol
 
 cd "$(dirname "$0")"
-IMAGE=$(./get-package-name.sh | tr '[:upper:]' '[:lower:]')
+IMAGE=$(./get-image-name.sh | tr '[:upper:]' '[:lower:]')
 
 echo ""
 echo "##### $IMAGE Docker Image Build Script #####"

--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#  Copyright (C) 2018-2019 LEIDOS.
+#  Copyright (C) 2018-2020 LEIDOS.
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of

--- a/docker/checkout.sh
+++ b/docker/checkout.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#  Copyright (C) 2018-2019 LEIDOS.
+#  Copyright (C) 2018-2020 LEIDOS.
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of

--- a/docker/get-component-version.sh
+++ b/docker/get-component-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#  Copyright (C) 2018-2019 LEIDOS.
+#  Copyright (C) 2018-2020 LEIDOS.
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of

--- a/docker/get-image-name.sh
+++ b/docker/get-image-name.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#  Copyright (C) 2018-2019 LEIDOS.
+#  Copyright (C) 2018-2020 LEIDOS.
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of

--- a/docker/get-repo-name.sh
+++ b/docker/get-repo-name.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#  Copyright (C) 2018-2019 LEIDOS.
+#  Copyright (C) 2018-2020 LEIDOS.
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of

--- a/docker/get-system-version.sh
+++ b/docker/get-system-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#  Copyright (C) 2018-2019 LEIDOS.
+#  Copyright (C) 2018-2020 LEIDOS.
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#  Copyright (C) 2018-2019 LEIDOS.
+#  Copyright (C) 2018-2020 LEIDOS.
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of


### PR DESCRIPTION
PR merge updated copyright info with develop branch, tested by building the image per CAR-1532. Found issues with the build-image.sh script, in that the image it creates does not have a hyphenated name. Confirmed that the issue was not unique to the feature/copyright_update branch by building once from the feature branch and then once from develop. See the following:
<img width="522" alt="delphiesr" src="https://user-images.githubusercontent.com/57960283/71921738-67b43300-3157-11ea-9c24-94541d316851.png">
